### PR TITLE
Use comparison instead of nembership check, Change Error Type.

### DIFF
--- a/spotifyapi/Album.py
+++ b/spotifyapi/Album.py
@@ -12,8 +12,8 @@ class Album():
     link = 'https://api.spotify.com/v1/search'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit not in range(50):
-      raise TypeError('limit must be under 50')
+    if limit >= 50:
+      raise ValueError('limit must be under 50')
 
     return requests.request(
       'GET',
@@ -41,8 +41,8 @@ class Album():
     link = 'https://api.spotify.com/v1/albums/' + albumID + '/tracks'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit not in range(50):
-      raise TypeError('limit must be under 50')
+    if limit >= 50:
+      raise ValueError('limit must be under 50')
 
     return requests.request(
       'GET',

--- a/spotifyapi/Artist.py
+++ b/spotifyapi/Artist.py
@@ -12,8 +12,8 @@ class Artist():
     link = 'https://api.spotify.com/v1/search'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit not in range(50):
-      raise TypeError('limit must be under 50')
+    if limit >= 50:
+      raise ValueError('limit must be under 50')
 
     return requests.request(
       'GET',
@@ -41,8 +41,8 @@ class Artist():
     link = 'https://api.spotify.com/v1/artists/' + artistID + '/albums'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit not in range(50):
-      raise TypeError('limit must be under 50')
+    if limit >= 50:
+      raise ValueError('limit must be under 50')
 
     return requests.request(
       'GET',

--- a/spotifyapi/Track.py
+++ b/spotifyapi/Track.py
@@ -12,8 +12,8 @@ class Track():
     link = 'https://api.spotify.com/v1/search'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit not in range(50):
-      raise TypeError('limit must be under 50')
+    if limit >= 50:
+      raise ValueError('limit must be under 50')
 
     return requests.request(
       'GET',


### PR DESCRIPTION
This PR makes two changes.

* Used comparison instead of creating a range object in every check, optimizes the performance.
* Changed the error type, in our case type is not wrong but the argument we are receiving has the right type but an inappropriate value, so raising a ValueError would be more reasonable