### PR TITLE
Create library specific errors with a generic exception class

### DIFF
--- a/spotifyapi/Album.py
+++ b/spotifyapi/Album.py
@@ -1,6 +1,8 @@
 # Import Packages
 import requests
 from .Util import encodeURIComponent
+from .exceptions import LimitOutOfRangeError
+
 
 # Album Class
 class Album():
@@ -12,8 +14,8 @@ class Album():
     link = 'https://api.spotify.com/v1/search'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit >= 50:
-      raise ValueError('limit must be under 50')
+    if not 0 < limit < 50:
+      raise LimitOutOfRangeError('Limit must be under 50.')
 
     return requests.request(
       'GET',
@@ -41,8 +43,8 @@ class Album():
     link = 'https://api.spotify.com/v1/albums/' + albumID + '/tracks'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit >= 50:
-      raise ValueError('limit must be under 50')
+    if not 0 < limit < 50:
+      raise LimitOutOfRangeError('Limit must be under 50.')
 
     return requests.request(
       'GET',

--- a/spotifyapi/Artist.py
+++ b/spotifyapi/Artist.py
@@ -1,6 +1,7 @@
 # Import Packages
 import requests
 from .Util import encodeURIComponent
+from .exceptions import LimitOutOfRangeError
 
 # Artist Class
 class Artist():
@@ -12,8 +13,8 @@ class Artist():
     link = 'https://api.spotify.com/v1/search'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit >= 50:
-      raise ValueError('limit must be under 50')
+    if not 0 < limit < 50:
+      raise LimitOutOfRangeError('Limit must be under 50.')
 
     return requests.request(
       'GET',
@@ -41,8 +42,8 @@ class Artist():
     link = 'https://api.spotify.com/v1/artists/' + artistID + '/albums'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit >= 50:
-      raise ValueError('limit must be under 50')
+    if not 0 < limit < 50:
+      raise LimitOutOfRangeError('Limit must be under 50.')
 
     return requests.request(
       'GET',

--- a/spotifyapi/Track.py
+++ b/spotifyapi/Track.py
@@ -1,6 +1,7 @@
 # Import Packages
 from .Util import encodeURIComponent
 import requests
+from .exceptions import LimitOutOfRangeError
 
 # Track Class
 class Track():
@@ -12,8 +13,8 @@ class Track():
     link = 'https://api.spotify.com/v1/search'
     header = {'Authorization': 'Bearer ' + self.token}
 
-    if limit >= 50:
-      raise ValueError('limit must be under 50')
+    if not 0 < limit < 50:
+      raise LimitOutOfRangeError('Limit must be under 50.')
 
     return requests.request(
       'GET',

--- a/spotifyapi/Track.py
+++ b/spotifyapi/Track.py
@@ -1,7 +1,7 @@
 # Import Packages
 from .Util import encodeURIComponent
 import requests
-from .exceptions import LimitOutOfRangeError
+from .exceptions import LimitOutOfRangeError, InvalidTrackIdError
 
 # Track Class
 class Track():
@@ -50,7 +50,7 @@ class Track():
     header = {'Authorization': 'Bearer ' + self.token}
 
     if ' ' in [char for char in trackID]:
-      raise TypeError('invalid track id provided')
+      raise InvalidTrackIdError("Invalid track has been provided.")
 
     link = 'https://api.spotify.com/v1/audio-features/' + trackID
 
@@ -64,7 +64,7 @@ class Track():
     header = {'Authorization': 'Bearer ' + self.token}
 
     if ' ' in [char for char in trackID]:
-      raise TypeError('invalid track id provided')
+      raise InvalidTrackIdError("Invalid track has been provided.")
 
     link = 'https://api.spotify.com/v1/audio-analysis/' + trackID
     

--- a/spotifyapi/exceptions.py
+++ b/spotifyapi/exceptions.py
@@ -1,0 +1,19 @@
+class SpotifyError(Exception):
+    """
+    Generic base class for exceptions.
+    """
+    def __init__(self, message):
+        self.message = message 
+
+    def __str__(self):
+        class_name = self.__class__.__name__
+        return f"{class_name}: {self.message}"
+
+class LimitOutOfRangeError(SpotifyError):
+    def __init__(self, message):
+        super().__init__(message)
+
+class InvalidTrackIdError(SpotifyError):
+    def __init__(self, message):
+        super().__init__(message)
+


### PR DESCRIPTION
I created generic SpotifyError class for implementing library specific exceptions. 

Now we can raise errors like this.
```python
    raise LimitOutOfRangeError("Limit is out of range.")
exceptions.LimitOutOfRangeError: LimitOutOfRangeError: Limit is out of range.
```
or
```python
    raise InvalidTrackIdError("Invalid track has been provided.")
exceptions.InvalidTrackIdError: InvalidTrackIdError: Invalid track has been provided.
```

